### PR TITLE
Updates to 1.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+	id 'fabric-loom' version '0.8-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version + "-" + project.minecraft_version
@@ -26,13 +26,8 @@ dependencies {
 processResources {
 	inputs.property "version", project.version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
+	filesMatching("fabric.mod.json") {
 		expand "version": project.version
-	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=21w05b
-yarn_mappings=21w05b+build.2
-loader_version=0.11.1
+minecraft_version=1.17
+yarn_mappings=1.17+build.13
+loader_version=0.11.6
 
 # Mod Properties
-mod_version = 1.3.6
+mod_version = 1.3.7
 maven_group = me.crimsondawn45
 archives_base_name = FabricShieldLib
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.30.1+1.17
+fabric_version=0.36.0+1.17

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk16

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,5 @@
-jdk:
-  - openjdk16
+before_install:
+  - export SDKMAN_DIR="/home/jitpack/sdkman" && curl -s "https://get.sdkman.io" | bash
+  - source "/home/jitpack/sdkman/bin/sdkman-init.sh"
+  - sdk install java 16.0.1.hs-adpt
+  - sdk use java 16.0.1.hs-adpt

--- a/src/main/java/me/crimsondawn45/fabricshieldlib/mixin/LivingEntityAccessor.java
+++ b/src/main/java/me/crimsondawn45/fabricshieldlib/mixin/LivingEntityAccessor.java
@@ -12,11 +12,11 @@ import net.minecraft.item.ItemStack;
 public interface LivingEntityAccessor {	
 	
 	@Invoker
-	boolean fabricshieldlib$invokeBlockedByShield(DamageSource source);
+	boolean invokeBlockedByShield(DamageSource source);
 
 	@Invoker
-	void fabricshieldlib$invokeDamageShield(float amount);
+	void invokeDamageShield(float amount);
 
 	@Invoker
-	void fabricshieldlib$invokeTakeShieldHit(LivingEntity attacker);
+	void invokeTakeShieldHit(LivingEntity attacker);
 }

--- a/src/main/java/me/crimsondawn45/fabricshieldlib/mixin/LivingEntityMixin.java
+++ b/src/main/java/me/crimsondawn45/fabricshieldlib/mixin/LivingEntityMixin.java
@@ -26,7 +26,7 @@ public class LivingEntityMixin {
 		ItemStack activeItem = entity.getActiveItem();
 		
 		if(!(entity.isInvulnerableTo(source) || entity.world.isClient || entity.isDead() || (source.isFire() && entity.hasStatusEffect(StatusEffects.FIRE_RESISTANCE)))) {
-			if (amount > 0.0F && ((LivingEntityAccessor)entity).fabricshieldlib$invokeBlockedByShield(source)) {
+			if (amount > 0.0F && ((LivingEntityAccessor)entity).invokeBlockedByShield(source)) {
 				
 				/*
 				 * Handle onBlockDamage Events
@@ -35,7 +35,7 @@ public class LivingEntityMixin {
 					FabricShield shield = (FabricShield) activeItem.getItem();
 					if(shield.hasEvent()) {
 						if(shield.getEvent().usesOnBlockDamage()) {
-							shield.getEvent().onBlockDamage(entity, source, amount, 0, entity.getActiveHand(), activeItem);;
+							shield.getEvent().onBlockDamage(entity, source, amount, 0, entity.getActiveHand(), activeItem);
 						}
 					}
 				}
@@ -48,14 +48,14 @@ public class LivingEntityMixin {
 				}
 
 				//Handle Shield
-				((LivingEntityAccessor)entity).fabricshieldlib$invokeDamageShield(amount);
+				((LivingEntityAccessor)entity).invokeDamageShield(amount);
 				amount = 0.0F;
 
 				if (!source.isProjectile()) {
 					Entity sourceEntity = source.getSource();
 					
 					if (sourceEntity instanceof LivingEntity) {
-					   ((LivingEntityAccessor)entity).fabricshieldlib$invokeTakeShieldHit((LivingEntity)sourceEntity);
+					   ((LivingEntityAccessor)entity).invokeTakeShieldHit((LivingEntity)sourceEntity);
 					}
 				}
 			}

--- a/src/main/resources/fabricshieldlib.mixins.json
+++ b/src/main/resources/fabricshieldlib.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "me.crimsondawn45.fabricshieldlib.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_16",
   "mixins": [
     "PlayerEntityMixin",
     "LivingEntityMixin",


### PR DESCRIPTION
I'm creating a PR here because I needed to do this for my own project and figured I might as well PR it.

This only updates to 1.17, with no other changes apart from renaming the invokers in LivingEntityAccessor because of an error. This shouldn't matter anyway as mixin merges identical invokers so the mod id prefix is unnecessary. Alternative you can specify the method name in the @Invoker("methodName") format and put the prefixes back if you want them

I've tested with the TestShield + Enchantment and all the debug messages work 👍 