### PR TITLE
Reintroduce FabricShieldEnchantment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,16 +51,14 @@ dependencies {
 	}
 
 	//Fabric ASM
-	/*
 	modImplementation("com.github.Chocohead:Fabric-ASM:v2.3") {
 		exclude (group: "net.fabricmc.fabric-api")
 	}
 	include "com.github.Chocohead:Fabric-ASM:v2.3"
-	*/
 }
 
 loom {
-	//accessWidenerPath = file("src/main/resources/fabricshieldlib.accesswidener")
+	accessWidenerPath = file("src/main/resources/fabricshieldlib.accesswidener")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.19.2+build.28
 loader_version=0.14.11
 
 # Mod Properties
-mod_version=1.6.1-lite-1.19
+mod_version=1.6.2-1.19
 maven_group=com.github.crimsondawn45
 archives_base_name=FabricShieldLib
 

--- a/src/main/java/com/github/crimsondawn45/fabricshieldlib/initializers/FabricShieldLib.java
+++ b/src/main/java/com/github/crimsondawn45/fabricshieldlib/initializers/FabricShieldLib.java
@@ -1,5 +1,11 @@
 package com.github.crimsondawn45.fabricshieldlib.initializers;
 
+import com.github.crimsondawn45.fabricshieldlib.lib.event.ShieldBlockCallback;
+import com.github.crimsondawn45.fabricshieldlib.lib.object.FabricShieldEnchantment;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.player.PlayerEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,17 +59,17 @@ public class FabricShieldLib implements ModInitializer {
      * Test shield item that does not support banners.
      */
     public static FabricShieldItem fabric_shield;
+    
+    /**
+     * Test shield enchantment.
+     */
+    public static FabricShieldEnchantment reflect_enchantment;
 
     /**
      * Recipe type and serializer for banner decoration recipe.
      */
     public static final SpecialRecipeSerializer<FabricShieldDecoratorRecipe> FABRIC_SHIELD_DECORATION_SERIALIZER;
     public static final RecipeType<FabricShieldDecoratorRecipe> FABRIC_SHIELD_DECORATION;
-
-    /**
-     * Test shield enchantment.
-     */
-    //public static FabricShieldEnchantment reflect_enchantment;
 
     static {
         //Registering Banner Recipe (Lib only)
@@ -89,11 +95,10 @@ public class FabricShieldLib implements ModInitializer {
 
             //Register Custom Shield
             fabric_banner_shield = Registry.register(Registry.ITEM, new Identifier(MOD_ID, "fabric_banner_shield"), new FabricBannerShieldItem(new Item.Settings().maxDamage(336).group(ItemGroup.COMBAT), 85, 9, Items.OAK_PLANKS, Items.SPRUCE_PLANKS));
-            fabric_shield = Registry.register(Registry.ITEM, new Identifier(MOD_ID, "fabric_shield"), new FabricShieldItem(new Item.Settings().maxDamage(336).group(ItemGroup.COMBAT), 100, 9, Items.OAK_PLANKS, Items.SPRUCE_PLANKS));			//Register Development Stuff
-            //reflect_enchantment = Registry.register(Registry.ENCHANTMENT, new Identifier(MOD_ID, "reflect_enchantment"), new FabricShieldEnchantment(Rarity.COMMON, false, false));
+            fabric_shield = Registry.register(Registry.ITEM, new Identifier(MOD_ID, "fabric_shield"), new FabricShieldItem(new Item.Settings().maxDamage(336).group(ItemGroup.COMBAT), 100, 9, Items.OAK_PLANKS, Items.SPRUCE_PLANKS));
+            reflect_enchantment = Registry.register(Registry.ENCHANTMENT, new Identifier(MOD_ID, "reflect_enchantment"), new FabricShieldEnchantment(Enchantment.Rarity.COMMON, false, false));
 
             //Test event: makes any shield with new enchantment reflect a 1/3rd of damage back to attacker
-            /*
             ShieldBlockCallback.EVENT.register((defender, source, amount, hand, shield) -> {
 
                 if(reflect_enchantment.hasEnchantment(shield)) {
@@ -109,7 +114,6 @@ public class FabricShieldLib implements ModInitializer {
 
                 return ActionResult.PASS;
             });
-            */
 
             //Test Event: if your shield gets disabled, give player speed
             ShieldDisabledCallback.EVENT.register((defender, hand, shield) -> {
@@ -117,7 +121,6 @@ public class FabricShieldLib implements ModInitializer {
                 return ActionResult.PASS;
             });
         }
-
         //Announce having finished starting up
         logger.info("Fabric Shield Lib Initialized!");
     }

--- a/src/main/java/com/github/crimsondawn45/fabricshieldlib/initializers/FabricShieldLibEarlyRiser.java
+++ b/src/main/java/com/github/crimsondawn45/fabricshieldlib/initializers/FabricShieldLibEarlyRiser.java
@@ -1,0 +1,16 @@
+package com.github.crimsondawn45.fabricshieldlib.initializers;
+
+import com.chocohead.mm.api.ClassTinkerers;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.MappingResolver;
+
+public class FabricShieldLibEarlyRiser implements Runnable {
+    
+    @Override
+    public void run() {
+        MappingResolver remapper = FabricLoader.getInstance().getMappingResolver();
+        String enchantmentTarget = remapper.mapClassName("intermediary", "net.minecraft.class_1886");
+        ClassTinkerers.enumBuilder(enchantmentTarget).addEnumSubclass("FABRIC_SHIELD", "com.github.crimsondawn45.fabricshieldlib.lib.core.ShieldEnchantmentTarget").build();
+    }
+    
+}

--- a/src/main/java/com/github/crimsondawn45/fabricshieldlib/lib/core/EnchantmentTargetMixin.java
+++ b/src/main/java/com/github/crimsondawn45/fabricshieldlib/lib/core/EnchantmentTargetMixin.java
@@ -1,0 +1,15 @@
+package com.github.crimsondawn45.fabricshieldlib.lib.core;
+
+import net.minecraft.enchantment.EnchantmentTarget;
+import net.minecraft.item.Item;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@SuppressWarnings("ALL") //Don't need this in mixins.json
+@Mixin(EnchantmentTarget.class)
+abstract class EnchantmentTargetMixin {
+    
+    @Shadow
+    public abstract boolean isAcceptableItem(Item item);
+    
+}

--- a/src/main/java/com/github/crimsondawn45/fabricshieldlib/lib/core/ShieldEnchantmentTarget.java
+++ b/src/main/java/com/github/crimsondawn45/fabricshieldlib/lib/core/ShieldEnchantmentTarget.java
@@ -1,0 +1,16 @@
+package com.github.crimsondawn45.fabricshieldlib.lib.core;
+
+import com.github.crimsondawn45.fabricshieldlib.lib.object.FabricShield;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+
+public class ShieldEnchantmentTarget extends EnchantmentTargetMixin {
+    
+    @Override
+    public boolean isAcceptableItem(Item item) {
+        return item == Items.SHIELD || item instanceof FabricShield;
+    }
+    
+}
+
+

--- a/src/main/java/com/github/crimsondawn45/fabricshieldlib/lib/object/FabricShieldEnchantment.java
+++ b/src/main/java/com/github/crimsondawn45/fabricshieldlib/lib/object/FabricShieldEnchantment.java
@@ -1,0 +1,61 @@
+package com.github.crimsondawn45.fabricshieldlib.lib.object;
+
+import com.chocohead.mm.api.ClassTinkerers;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.EnchantmentTarget;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Enchantment that works on fabric shields and vanilla shield(Needs events to do anything).
+ */
+public class FabricShieldEnchantment extends Enchantment {
+    public static final EnchantmentTarget TARGET = ClassTinkerers.getEnum(EnchantmentTarget.class, "FABRIC_SHIELD");
+    private boolean isTreasure;
+    private boolean isCurse;
+    
+    /**
+     * @param weight rarity of enchantment.
+     * @param isTreasure if enchantment is a treasure enchantment.
+     */
+    public FabricShieldEnchantment(Rarity weight, boolean isTreasure, boolean isCurse) {
+        super(weight, TARGET, new EquipmentSlot[] { EquipmentSlot.MAINHAND, EquipmentSlot.OFFHAND });
+        this.isTreasure = isTreasure;
+        this.isCurse = isCurse;
+    }
+    
+    /**
+     * @param weight rarity of enchantment.
+     * @param isTreasure if enchantment is a treasure enchantment.
+     */
+    public FabricShieldEnchantment(Rarity weight, boolean isTreasure) {
+        this(weight, isTreasure, false);
+    }
+    
+    /**
+     * @param weight rarity of enchantment.
+     */
+    public FabricShieldEnchantment(Rarity weight) {
+        this(weight, false, false);
+    }
+    
+    @Override
+    public boolean isTreasure() {
+        return this.isTreasure;
+    }
+    
+    @Override
+    public boolean isCursed() {
+        return this.isCurse;
+    }
+    
+    /**
+     * @param stack item stack.
+     * @return if item has this enchantment.
+     */
+    public boolean hasEnchantment(ItemStack stack) {
+        return EnchantmentHelper.getLevel(this, stack) > 0;
+    }
+    
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -38,6 +38,9 @@
       "com.github.crimsondawn45.fabricshieldlib.initializers.FabricShieldLibClient"
 
     ],
+    "mm:early_risers":[
+      "com.github.crimsondawn45.fabricshieldlib.initializers.FabricShieldLibEarlyRiser"
+    ],
     "modmenu":[
       "com.github.crimsondawn45.fabricshieldlib.lib.config.FabricShieldLibModMenuIntegration"
     ]
@@ -45,11 +48,13 @@
   "mixins": [
     "fabricshieldlib.mixins.json"
   ],
+  "accessWidener": "fabricshieldlib.accesswidener",
   "depends": {
     "fabricloader": ">=0.14.8",
     "fabric": "*",
     "minecraft": "1.19.x",
     "java": ">=17",
+    "mm":">=2.3",
     "cloth-config":">=7.0.72"
   }
 }

--- a/src/main/resources/fabricshieldlib.accesswidener
+++ b/src/main/resources/fabricshieldlib.accesswidener
@@ -1,0 +1,2 @@
+accessWidener   v2      named
+extendable      class   net/minecraft/enchantment/EnchantmentTarget


### PR DESCRIPTION
Managed to reintroduce enchantment support, fixes #82.
The original problem should be caused by unnecessarily adding the `EnchantmentTargetMixin` to `mixins.json`.